### PR TITLE
Fixes related to plotting options for scanpy wrappers (#18)

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -12,7 +12,7 @@ scanpy-normalise-data.py -i input.h5
                          -o output.h5
                          -F '${output_format}'
 			 -s '${scale_factor}'
-                         '${save_raw}'
+                         ${save_raw}
 ]]></command>
 
   <inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
@@ -28,40 +28,12 @@ scanpy-run-pca.py -i input.h5
     #end if
 #end if
 
-#if $do_plotting.plot
-                  -P output.png
-                  --projectio $do_plotting.projection
-                  --components $do_plotting.components
-    #if $do_plotting.color_by
-                  --color $do_plotting.color_by
-    #end if
-    #if $do_plotting.groups
-                  --group $do_plotting.groups
-    #end if
-    #if $do_plotting.use_raw
-                  --use-raw
-    #end if
-    #if $do_plotting.palette
-                  --palette $do_plotting.palette
-    #end if
-    #if $do_plotting.show_edges
-                  --edges
-    #end if
-    #if $do_plotting.show_arrows
-                  --arrows
-    #end if
-    #if not $do_plotting.color_order
-                  --no-sort-order
-    #end if
-    #if $do_plotting.omit_frame
-                  --frameoff
-    #end if
-#end if
-
 #if $extra_outputs
 #set extras = ' '.join(['--output-{}-file {}.csv'.format(x, x) for x in str($extra_outputs).split(',')])
                   $extras
 #end if
+
+@PLOT_OPTS@
 ]]></command>
 
   <inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -35,35 +35,7 @@ scanpy-run-tsne.py -i input.h5
     #end if
 #end if
 
-#if $do_plotting.plot
-                   -P output.png
-                   --projectio $do_plotting.projection
-                   --components $do_plotting.components
-    #if $do_plotting.color_by
-                   --color $do_plotting.color_by
-    #end if
-    #if $do_plotting.groups
-                   --group $do_plotting.groups
-    #end if
-    #if $do_plotting.use_raw
-                   --use-raw
-    #end if
-    #if $do_plotting.palette
-                   --palette $do_plotting.palette
-    #end if
-    #if $do_plotting.show_edges
-                   --edges
-    #end if
-    #if $do_plotting.show_arrows
-                   --arrows
-    #end if
-    #if not $do_plotting.color_order
-                   --no-sort-order
-    #end if
-    #if $do_plotting.omit_frame
-                   --frameoff
-    #end if
-#end if
+@PLOT_OPTS@
 ]]></command>
 
   <inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -38,35 +38,7 @@ scanpy-run-umap.py -i input.h5
     #end if
 #end if
 
-#if $do_plotting.plot
-                   -P output.png
-                   --projectio $do_plotting.projection
-                   --components $do_plotting.components
-    #if $do_plotting.color_by
-                   --color $do_plotting.color_by
-    #end if
-    #if $do_plotting.groups
-                   --group $do_plotting.groups
-    #end if
-    #if $do_plotting.use_raw
-                   --use-raw
-    #end if
-    #if $do_plotting.palette
-                   --palette $do_plotting.palette
-    #end if
-    #if $do_plotting.show_edges
-                   --edges
-    #end if
-    #if $do_plotting.show_arrows
-                   --arrows
-    #end if
-    #if not $do_plotting.color_order
-                   --no-sort-order
-    #end if
-    #if $do_plotting.omit_frame
-                   --frameoff
-    #end if
-#end if
+@PLOT_OPTS@
 ]]></command>
 
   <inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros.xml
@@ -1,6 +1,37 @@
 <macros>
   <token name="@TOOL_VERSION@">0.0.3</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
+  <token name="@PLOT_OPTS@">
+#if $do_plotting.plot
+                  -P output.png
+                  --projectio $do_plotting.projection
+                  --components $do_plotting.components
+    #if $do_plotting.color_by
+                  --color-by $do_plotting.color_by
+    #end if
+    #if $do_plotting.groups
+                  --group $do_plotting.groups
+    #end if
+    #if $do_plotting.use_raw
+                  --use-raw
+    #end if
+    #if $do_plotting.palette
+                  --palette $do_plotting.palette
+    #end if
+    #if $do_plotting.show_edges
+                  --edges
+    #end if
+    #if $do_plotting.show_arrows
+                  --arrows
+    #end if
+    #if not $do_plotting.color_order
+                  --no-sort-order
+    #end if
+    #if $do_plotting.omit_frame
+                  --frameoff
+    #end if
+#end if
+  </token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="1.3.2">scanpy</requirement>
@@ -37,7 +68,7 @@
     </param> 
   </xml>
   <xml name="output_plot_params">
-    <param name="color_by" argument="--color" type="text" value="n_genes" label="Color by attributes, comma separated strings"/>
+    <param name="color_by" argument="--color-by" type="text" value="n_genes" label="Color by attributes, comma separated strings"/>
     <param name="groups" argument="--groups" type="text" optional="ture" label="Restrict plotting to named groups, comma separated strings"/>
     <param name="projection" argument="--projection" type="select" label="Plot projection">
       <option value="2d" selected="true">2D</option>


### PR DESCRIPTION
* Fix option ${save_raw} in <command/>

If boolean ${opt} is set in the recommended way, i.e. "--opt" when
true and "" when false, then add single quotes around, i.e. '${opt}'
will break the executed command, as argparse will treat '' as an
empty positional argument which it doesn't recognise. This fix simply
removes the double quote as a temporary measure. Better ways need to
be sought.

* Move plotting related part of the command in macros as @PLOT_OPTS@

Also change --color to --color-by to accommodate change in bioconda
wrapper.